### PR TITLE
Upgrade to Expo SDK v21 to run on Expo

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
     "description": "Photo gallery with Shared Element Transition",
     "slug": "photo-gallery",
     "privacy": "public",
-    "sdkVersion": "19.0.0",
+    "sdkVersion": "21.0.0",
     "version": "1.0.0",
     "orientation": "portrait",
     "primaryColor": "#cccccc",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "private": true,
   "main": "node_modules/expo/AppEntry.js",
   "dependencies": {
-    "expo": "^19.0.0",
+    "expo": "^21.0.0",
     "prop-types": "^15.5.10",
     "react": "16.0.0-alpha.12",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-19.0.0.tar.gz"
+    "react-native": "https://github.com/expo/react-native/archive/sdk-21.0.2.tar.gz"
   }
 }


### PR DESCRIPTION
The current Expo app does not support apps made with SDK v19, so the Snack link is currently useless.

Making the minimal change of upgrading to SDK v20 results in this error:
```
`ScrollView` has no propType for native prop `RCTScrollView.contentInsetAdjustmentBehavior`
```
which as instructed in react-community/create-react-native-app#418 can be fixed by upgrading to v21. With this change then `yarn install` it worked for me.